### PR TITLE
fix: remove whitespace from phone input

### DIFF
--- a/scripts/profile.js
+++ b/scripts/profile.js
@@ -81,7 +81,7 @@ const init = async () => {
     process.exit(0)
   }
 
-  const phoneNumber = phoneNumberMatch.replace(/\s/g, '')
+  const phoneNumber = phoneNumberInput.replace(/\s/g, '')
   const [, phoneNumberNation, phoneNumberUser] = phoneNumberMatch
 
   const profile = {


### PR DESCRIPTION
The example is wrong, it's trying to do `.replace` from the regex match, not the input string